### PR TITLE
Rollback d3dx.ini to 71c43b1

### DIFF
--- a/d3dx.ini
+++ b/d3dx.ini
@@ -10,9 +10,10 @@
 ; Resource sections (Replaced shaders in these mods should still go in
 ; ShaderFixes for now, unless the modders want to use CustomShaders or
 ; ShaderRegex to keep them standalone).
-;include_recursive = Mods
+include_recursive = Mods
 exclude_recursive = DISABLED*
-exclude_recursive = desktop.ini
+
+include = ShaderFixes\help.ini
 
 ; Uncomment to enable a custom shader that allows the stereo output mode to be
 ; upscaled. NOTE: uncomment only if 'upscaling' and resolution are not zero in
@@ -106,6 +107,8 @@ crash=0
 ; 7 = Reversed Line interlacing
 ;$\ShaderFixes\3dvision2sbs.ini\mode = 0
 
+global $costume_mods = 1
+global persist $version = 7.0
 
 ;------------------------------------------------------------------------------------------------------
 ; Custom settings override for any of [convergence, separation, x, y, z, w]
@@ -252,7 +255,7 @@ crash=0
 ; 0: Release mode is with shader hunting disabled, optimized for speed.
 ; 1: Hunting mode enabled
 ; 2: Hunting mode "soft disabled" - can be turned on via the toggle_hunting key
-hunting=1
+hunting=2
 
 ; Highlight mode of currently selected shader / rendertarget.
 ; "skip" = skip shader. don't render anything using the currently selected shader.
@@ -273,7 +276,7 @@ next_marking_mode = no_modifiers VK_DECIMAL VK_NUMPAD0
 ; "mono_snapshot" = take mono screenshot (previously called mark_snapshot=1)
 ; "stereo_snapshot" = take stereo screenshot (previously called mark_snapshot=2)
 ; "snapshot_if_pink" = limit mono/stereo_snapshot to when marking_mode=pink
-marking_actions = clipboard regex hlsl asm stereo_snapshot snapshot_if_pink
+marking_actions = hlsl asm clipboard regex snapshot_if_pink
 
 ; Key bindings: For A-Z and 0-9 on the number row, just use that single
 ; character. For everything else (including mouse buttons), use the virtual key
@@ -374,7 +377,7 @@ repeat_rate=6
 ; be very error prone - the recommended workflow is to dump the shaders to disk
 ; and check the most recently modified file in ShaderFixes, but advanced users
 ; can enable this if they want it:
-verbose_overlay = 0
+verbose_overlay = 1
 
 ; tunable parameter to use in modified shaders as variable (StereoParams.Load(int3(1,0,0)).xyzw)
 ; enabling tuning results in a small performance hit because the parameter texture
@@ -389,7 +392,7 @@ verbose_overlay = 0
 ; Dumps out a flight log of DirectX state changes and the contents of each
 ; render target after every immediate draw call for the next frame. Takes up a
 ; large amount of space, so disabled by default.
-;analyse_frame = no_modifiers VK_F8
+analyse_frame = no_modifiers VK_F8
 
 ; analyse_options specifies options for the frame analysis feature. Options can
 ; be combined by separating them with a space.
@@ -477,7 +480,7 @@ verbose_overlay = 0
 ; frame analysis cannot otherwise see (e.g. "dump = ResourceDepthBuffer"). Use
 ; additional "dump" commands to dump multiple resources.
 ;
-;analyse_options = dump_rt jps clear_rt
+analyse_options = dump_rt dump_tex dump_cb dump_vb dump_ib buf txt
 
 
 
@@ -530,25 +533,20 @@ allow_platform_update=1
 [Loader]
 ; Target process to load into. You can optionally include part of the directory
 ; structure in case the game's executable name is generic.
-target = C:\Program Files\Epic Games\ArknightsEndfieldgowoU\games\EndField Game\Endfield.exe
 
-; Normally, the above target setting is only used when 3DMigoto is loaded from
-; outside the game directory via the external loader (and is mandatory in that
-; case). If you want to enable that test even when the loader is not in use
-; (for example, to prevent 3DMigoto from interfering with a launcher or
-; configuration application), uncomment this line. Note that this test occurs
-; after the loader check, so 3DMigoto's DLL will still be loaded into memory
-; but will not be active:
-;check_target_even_without_loader = true
+; !!!IMPORTANT!!! Try seeing if this works before changing it to the full Genshin path
+; In 99% of cases this should work without needing to make any changes
+target = Endfield.exe
+
 
 ; This tells the loader where to find 3DMigoto. This DLL must be located
 ; in the same directory as 3DMigoto Loader.exe and will be loaded in the target
 ; process under the same name. If d3d11.dll doesn't work try 3dmigoto.dll
-;module = d3d11.dll
+module = d3d11.dll
 
 ; Uncomment to always elevate the loader to support games that run as admin.
 ; This will display a UAC prompt so only enable it if you actually need it.
-;require_admin = true
+require_admin = true
 
 ; Automatically launch the game from the loader. If you put the executable name
 ; here than the loader will need to be located in the game directory. You can
@@ -853,6 +851,40 @@ fix_sv_position=0
 ;------------------------------------------------------------------------------------------------------
 ; Shader manipulations without patches + shader filtering.
 ;------------------------------------------------------------------------------------------------------
+
+; Shader override for Genshin
+; This is very inefficient, but yet to figure out how to override on certain textures without it
+[ShaderRegexEnableTextureOverrides]
+shader_model = vs_4_0 vs_4_1 vs_5_0 vs_5_1
+run = CommandListSkin
+
+[ShaderOverrideCharacter]
+hash = 653c63ba4a73ca8b
+run = CommandListSkin
+
+[CommandListSkin]
+if $costume_mods
+	checktextureoverride = ps-t0
+	checktextureoverride = ps-t1
+	checktextureoverride = ps-t2
+	checktextureoverride = ps-t3
+	checktextureoverride = vb0
+	checktextureoverride = vb1
+	checktextureoverride = vb2
+	checktextureoverride = ib
+	checktextureoverride = ps-t13
+	checktextureoverride = ps-t14
+	checktextureoverride = ps-t15
+	checktextureoverride = ps-t16
+	checktextureoverride = ps-t17
+	x140 = 0
+endif
+
+[KeyToggleMods]
+Key = no_modifiers F6
+$costume_mods = 0,1
+type = cycle
+
 ;[ShaderOverride1]
 ;Hash=69732c4f23cb6c48
 ; Custom stereo separation value while rendering objects using this shader.


### PR DESCRIPTION
Rollback d3dx.ini to 71c43b1 and adds additional textureoverrides for endfield.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added costume mod toggle system with keyboard controls
  * Enhanced texture override capabilities for improved graphics customization

* **Improvements**
  * Expanded debugging and analysis output options
  * Increased verbose feedback for better diagnostics

* **Configuration Updates**
  * Updated version to 7.0
  * Improved compatibility and loader settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->